### PR TITLE
Change input encoding to UTF-8

### DIFF
--- a/videosnap/main.m
+++ b/videosnap/main.m
@@ -41,7 +41,7 @@ int main(int argc, const char * argv[]) {
 	// convert C argv values array to NSArray
 	NSMutableArray *args = [[NSMutableArray alloc] initWithCapacity: argc];
 	for (int i = 0; i < argc; i++) {
-		[args addObject: [NSString stringWithCString: argv[i] encoding:NSASCIIStringEncoding]];
+		[args addObject: [NSString stringWithCString: argv[i] encoding:NSUTF8StringEncoding]];
 	}
     
     // opt in to see connected iOS screen devices


### PR DESCRIPTION
I figured I can quickly fix the issue (#18) I've opened earlier today.

The dafault encoding for macOS Terminal is UTF-8. So I changed decoding of the arguments to UTF-8.

<img width="340" alt="Screenshot of default Terminal settings" src="https://user-images.githubusercontent.com/708312/94943975-d18c1e00-04d8-11eb-9de5-1c07be2179e7.png">

Here is a Terminal output showing it works:

```
kaspar@Matejs-MacBook-Pro bin % ./videosnap -l
Found 3 available video devices:
* FaceTime HD Camera (Built-in)
* Kašpar’s iPad
* Kašpar's iPhone XS
kaspar@Matejs-MacBook-Pro bin % ./videosnap --no-audio -d "Kašpar’s iPad"     
Started capture (ctrl+c to stop)...
^C
Captured 5.11 seconds of video to 'movie.mov'
```

---
#### :memo: Checklist

Please check this list and leave it intact for the reviewer. Thanks! :heart:

- [ ] Commit messages provide context (why not just what, some tips [here](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)).
- [x] If relevant, mention GitHub issue number above and include in a commit message.
- [x] Latest code from master merged.
- [ ] New behaviour has test coverage.
- [x] Avoid duplicating code.
- [x] No commented out code.
- [ ] Avoid comments for your code, write code that explains itself.
- [x] Changes are simple, useful, clear and brief.
