### PR TITLE
Add support for explicit FullHD and HD4k setting

### DIFF
--- a/videosnap/Constants.m
+++ b/videosnap/Constants.m
@@ -20,5 +20,7 @@ NSString *const DEFAULT_ENCODING_PRESET = @"Medium";
 // Low - Suitable for 3G sharing (actual values may change)
 // 640x480 - 640x480 VGA (check its supported before setting it)
 // 1280x720 - 1280x720 720p HD (check its supported before setting it)
+// 1920x1080 - 1920x1080 Full HD (check its supported before setting it)
+// 3840x2160 - 3840x2160 HD4k (check its supported before setting it)
 
-NSString *const DEFAULT_ENCODING_PRESETS   = @"High, Medium, Low, 640x480, 1280x720";
+NSString *const DEFAULT_ENCODING_PRESETS   = @"High, Medium, Low, 640x480, 1280x720, 1920x1080, 3840x2160";


### PR DESCRIPTION
Explain what you're changing and why here.

Adding Full HD and HD4k options, see https://developer.apple.com/documentation/avfoundation/avcapturesession/preset

Test report:
```
vincent@vmbp videosnap % /Users/vincent/Documents/videosnap/build/pkgroot/usr/local/bin/videosnap -d "Insta360 Link" -p "3840x2160" -v 
(discovering devices)
(opting in for connected DAL devices, may delay or fail when connecting to DAL assistant port)
(opting in for screen capture devices)
(waiting 2 secs for devices to connect to DAL assistant)
(no filename specified, using default: movie-2023-12-02-203319.mov)
(options before recording)
  delay:    0.50s
  duration: 0.00s
  file:     movie-2023-12-02-203319.mov
  video:    3840x2160
  audio:    HQ AAC
  device:   Insta360 Link
            UVC Camera VendorID_11802 ProductID_19457 - Insta360
(initializing capture session)
(adding video device)
(adding audio device)
(adding movie file output)
(set capture framerate to 30 fps)
(setting encoding preset)
(starting capture session)
(delaying for 0.50 seconds)
(delay period ended)
(starting capture to file at 'movie-2023-12-02-203319.mov')
Started capture (ctrl+c to stop, ctrl+z to pause) ...
^C
(caught signal: [2])
(stopping recording)
(finished writing to movie file)
(stopping capture session)

Captured 7.53 seconds of video to 'movie-2023-12-02-203319.mov'
```

---
#### :memo: Checklist

Please check this list and leave it intact for the reviewer. Thanks! :heart:

- [x] Commit messages provide context (why not just what, some tips [here](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)).
- [x] If relevant, mention GitHub issue number above and include in a commit message.
- [x] Latest code from master merged.
- [x] New behaviour has test coverage.
- [x] Avoid duplicating code.
- [x] No commented out code.
- [x] Avoid comments for your code, write code that explains itself.
- [x] Changes are simple, useful, clear and brief.
